### PR TITLE
WIP: Add fluentd logging and kibana service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: "3.8"
 services:
+  ##
+  # Application services
+  ##
   frontend:
     image: tomasbalt/dcu_project_search_frontend:${FE_VERSION}
     environment:
@@ -17,6 +20,14 @@ services:
       - ${FRONTEND_SSL_CERT}:${FRONTEND_SSL_CERT}
     # use host ports
     network_mode: "host"
+    # where to write logs
+    logging:
+      driver: "fluentd"
+      options:
+        fluentd-address: ${FLUENTD_ADDRESS}
+        tag: frontend
+        # connect to driver once it is available
+        fluentd-async-connect: "true"
   backend:
     image: tomasbalt/dcu_project_search_backend:${BE_VERSION}
     environment:
@@ -31,6 +42,41 @@ services:
       - ${BACKEND_SSL_CERT}:${BACKEND_SSL_CERT}
     # use host ports
     network_mode: "host"
+    # where to write logs
+    logging:
+      driver: "fluentd"
+      options:
+        fluentd-address: ${FLUENTD_ADDRESS}
+        tag: backend
+        # connect to driver once it is available
+        fluentd-async-connect: "true"
+  ##
+  # Logging and management services
+  ##
+  # logging driver
+  fluentd:
+    image: tomasbalt/dcu_project_search_fluentd:${FLUENTD_IMAGE_VERSION}
+    environment:
+      # Set the name of the fluentd configuration file
+      - FLUENTD_CONF=fluentd.conf
+      - ES_HOST=${ES_HOST}
+    # use host ports
+    network_mode: "host"
+    ports:
+      # HTTP input support
+      - "9880:9880"
+      # TCP input support
+      - "24224:24224"
+      - "24224:24224/udp"
+  # elasticsearch and logs visualisation app
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.9.2
+    environment:
+      - ELASTICSEARCH_HOSTS=${ES_HOST}
+    # use host ports
+    network_mode: "host"
+    ports:
+      - "5601:5601"
 
 volumes:
   frontend:

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,0 +1,13 @@
+# fluentd/Dockerfile
+
+# Base image
+FROM fluent/fluentd:v1.11.4-debian-1.0
+
+# Use root account for dependencies
+USER root
+
+# Install dependencies
+RUN ["gem", "install", "fluent-plugin-elasticsearch", "--version", "4.2.0"]
+
+# Copy configuration file
+COPY ./fluentd.conf /fluentd/etc/

--- a/fluentd/fluentd.conf
+++ b/fluentd/fluentd.conf
@@ -1,0 +1,38 @@
+# Receive logs via TCP, i.e. logs from Docker container.
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+
+# Receive logs via HTTP, i.e. from manual log insertion.
+<source>
+  @type http
+  port 9880
+  bind 0.0.0.0
+</source>
+
+<filter **>
+  @type parser
+  key_name log
+  <parse>
+    # Parse log into Apache fields https://docs.fluentd.org/parser/apache2
+    @type apache2
+  </parse>
+</filter>
+
+<match **>
+  @type copy
+  <store>
+    @type elasticsearch
+    # Pass elasticsearch host from environment variables
+    hosts "#{ENV['ES_HOST']}"
+    index_name logs
+    include_tag_key true
+    tag_key @log_name
+    flush_interval 1s
+  </store>
+  <store>
+    @type stdout
+  </store>
+</match>

--- a/manual-logs.js
+++ b/manual-logs.js
@@ -1,0 +1,81 @@
+// Node script to send each line of a log file in Docker Compose stdout format to fluentd
+
+const fs = require("fs");
+const readline = require("readline");
+const http = require("http");
+const https = require("https");
+
+// Command line arguments
+const args = process.argv.slice(2);
+
+if (args.length !== 1) {
+  console.error("Usage: node manual-logs.js [logfile]");
+  process.exit(1);
+}
+
+const IS_HTTPS = process.env.IS_HTTPS || false;
+
+const httpLib = IS_HTTPS ? https : http;
+
+const httpOptions = {
+  hostname: process.env.FLUENTD_HOSTNAME || "localhost",
+  port: process.env.FLUENTD_PORT || 9880,
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+  },
+};
+
+const DOCKER_COMPOSE_SERVICE_SEPARATOR = "|";
+
+function parseComposeLog(line) {
+  const idx = line.indexOf(DOCKER_COMPOSE_SERVICE_SEPARATOR);
+  return {
+    composeService: line.substring(0, idx).trim(),
+    log: line.substring(idx + 1).trim(),
+  };
+}
+
+function processLogLine(line) {
+  const { composeService, log } = parseComposeLog(line);
+  const data = {
+    log,
+  };
+
+  const options = {
+    path: `/${composeService}`,
+    ...httpOptions,
+  };
+  const req = httpLib.request(options, (res) => {
+    if (res.statusCode !== 200) {
+      console.error(res.statusCode);
+    }
+    res.on("data", (d) => {
+      process.stdout.write(d);
+    });
+  });
+
+  req.on("error", (error) => {
+    console.error(error);
+  });
+  req.write(JSON.stringify(data));
+  req.end();
+}
+
+async function processLogs(file) {
+  const fileStream = fs.createReadStream(file);
+
+  const lineReader = readline.createInterface({
+    input: fileStream,
+    // Recognize all line breaks
+    crlfDelay: Infinity,
+  });
+
+  for await (const line of lineReader) {
+    processLogLine(line);
+  }
+}
+
+const logFile = args[0];
+
+processLogs(logFile);


### PR DESCRIPTION
Switch to fluentd logging driver. Add kibana.

TODO items:
* Improve the logs being indexed in ElasticSearch - include time, include derived fields (query of searches, user agent break down).
* Accept logs that don't follow the Apache2 (morgan) format.
* Add secured kibana link to the frontend.